### PR TITLE
feat(versioned_constants): load versioned constants from environment variables with fallback to defaults

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3617,6 +3617,7 @@ version = "0.1.0"
 dependencies = [
  "blockifier",
  "cairo-lang-starknet-classes",
+ "log",
  "rpc-client",
  "rstest 0.18.2",
  "serde",

--- a/crates/rpc-replay/Cargo.toml
+++ b/crates/rpc-replay/Cargo.toml
@@ -8,6 +8,7 @@ license-file.workspace = true
 [dependencies]
 blockifier = { workspace = true }
 cairo-lang-starknet-classes = { workspace = true }
+log = { workspace = true }
 rpc-client = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/rpc-replay/src/block_context.rs
+++ b/crates/rpc-replay/src/block_context.rs
@@ -1,4 +1,6 @@
+use std::env;
 use std::num::NonZeroU128;
+use std::path::Path;
 
 use blockifier::blockifier::block::{BlockInfo, GasPrices};
 use blockifier::bouncer::BouncerConfig;
@@ -62,10 +64,25 @@ pub fn build_block_context(
         },
     };
 
-    let versioned_constants = VersionedConstants::get(starknet_version);
+    // let versioned_constants = VersionedConstants::get(starknet_version);
+
+    // Check for custom versioned constants path
+    let versioned_constants = if let Ok(path) = env::var("SNOS_BLOCKIFIER_VERSIONED_CONSTANTS_PATH") {
+        log::info!("Loading versioned constants from path: {}", path);
+        // Try to load versioned constants from the specified JSON file
+        VersionedConstants::try_from(Path::new(&path)).map_err(|e| {
+            log::error!("Failed to load versioned constants from file {}, {}", path, e);
+            FeltConversionError::CustomError(format!("Failed to load versioned constants from file: {}", e))
+        })?
+    } else {
+        log::info!("Env for versioned constants not set. Using default values");
+        // Use the default versioned constants from the library
+        VersionedConstants::get(starknet_version).clone()
+    };
+
     let bouncer_config = BouncerConfig::max();
 
-    Ok(BlockContext::new(block_info, chain_info, versioned_constants.clone(), bouncer_config))
+    Ok(BlockContext::new(block_info, chain_info, versioned_constants, bouncer_config))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
- Introduced logging to track the loading of versioned constants from a custom path or default values.
- Updated dependencies to include the `log` crate in both `Cargo.toml` and `Cargo.lock` for enhanced logging capabilities.

Issue Number: N/A

## Type

- [ ] feature
- [ ] bugfix
- [ ] dev (no functional changes, no API changes)
- [ ] fmt (formatting, renaming)
- [ ] build
- [ ] docs
- [ ] testing

## Description


## Breaking changes?

- [ ] yes
- [ ] no
